### PR TITLE
Message router changes

### DIFF
--- a/Rock.Messaging.UnitTests/Routing/AppDomainTypeLocatorTests.cs
+++ b/Rock.Messaging.UnitTests/Routing/AppDomainTypeLocatorTests.cs
@@ -33,6 +33,12 @@ namespace AppDomainTypeLocatorTests
             }
 
             [Test]
+            public void WillNotReturnATypeIfNoMessageHandlerExistsForThatType()
+            {
+                Assert.That(() => _locator.GetMessageType(typeof(OrphanedCommand).Name), Throws.Exception);
+            }
+
+            [Test]
             public void ThrowsAnExceptionIfMoreThanOneTypeIsFound()
             {
                 Assert.That(() => _locator.GetMessageType("BazMessage1"), Throws.Exception);
@@ -87,6 +93,10 @@ namespace AppDomainTypeLocatorTests
         }
 
         public class FooCommand4
+        {
+        }
+
+        public class OrphanedCommand
         {
         }
 


### PR DESCRIPTION
1. When calling AppDomainTypeLocator.GetMessageType, only successfully get the message type if a corresponding message handler type can be located.
2. MessageRouter optimization: Only call ITypeLocator.GetMessageHandlerType once per message type.