### PR TITLE
CompositeMessagingScenarioFactory

### DIFF
--- a/Rock.Messaging.IntegrationTests/App.config
+++ b/Rock.Messaging.IntegrationTests/App.config
@@ -13,5 +13,7 @@
     <messagingScenarioFactory type="Rock.Messaging.AnotherMessagingScenarioFactory, Rock.Messaging.IntegrationTests">
       <boolData>true</boolData>
     </messagingScenarioFactory>
+      
+    <messagingScenarioFactory type="Rock.Messaging.PermissiveMessagingScenarioFactory, Rock.Messaging.IntegrationTests" />
   </rock.messaging>
 </configuration>

--- a/Rock.Messaging.IntegrationTests/CompositeMessagingScenarioTests.cs
+++ b/Rock.Messaging.IntegrationTests/CompositeMessagingScenarioTests.cs
@@ -1,0 +1,41 @@
+﻿using NUnit.Framework;
+
+namespace Rock.Messaging
+{
+    [TestFixture]
+    class CompositeMessagingScenarioTests
+    {
+        [Test]
+        public void IfMultipleFactoriesMatchTheProvidedNameThenTheFirstFactoryToAppearInConfigIsSelected()
+        {
+            // There are three factories in config, in this order:
+            // ExamplMessagingScenarioFactory
+            //     HasScenario returns true when the name parameter is "foo"
+            // AnotherMessagingScenarioFactory
+            //     HasScenario returns true when the name parameter is "foo" or "bar"
+            // PermissiveMessagingScenarioFactory
+            //     HasScenario returns true when the name parameter is *not* "qux"
+
+            var testReceiver = (TestReceiver)MessagingScenarioFactory.CreateQueueConsumer("foo");
+
+            Assert.That(testReceiver.Name, Is.EqualTo("foo"));
+            Assert.That(testReceiver.FactoryType, Is.EqualTo(typeof(ExampleMessagingScenarioFactory)));
+
+            testReceiver = (TestReceiver)MessagingScenarioFactory.CreateQueueConsumer("bar");
+
+            Assert.That(testReceiver.Name, Is.EqualTo("bar"));
+            Assert.That(testReceiver.FactoryType, Is.EqualTo(typeof(AnotherMessagingScenarioFactory)));
+
+            testReceiver = (TestReceiver)MessagingScenarioFactory.CreateQueueConsumer("baz");
+
+            Assert.That(testReceiver.Name, Is.EqualTo("baz"));
+            Assert.That(testReceiver.FactoryType, Is.EqualTo(typeof(PermissiveMessagingScenarioFactory)));
+        }
+
+        [Test]
+        public void IfNoFactoriesMatchTheProvidedNameThenAnInvalidOperationExceptionIsThrown()
+        {
+            Assert.That(() => MessagingScenarioFactory.CreateQueueConsumer("qux"), Throws.InvalidOperationException);
+        }
+    }
+}

--- a/Rock.Messaging.IntegrationTests/ConfigTests.cs
+++ b/Rock.Messaging.IntegrationTests/ConfigTests.cs
@@ -12,10 +12,11 @@ namespace Rock.Messaging
 
             var factory = (CompositeMessagingScenarioFactory)MessagingScenarioFactory.Current;
 
-            Assert.That(factory.Factories, Has.Length.EqualTo(2));
+            Assert.That(factory.Factories, Has.Length.EqualTo(3));
 
             Assert.That(factory.Factories, Has.Exactly(1).InstanceOf<ExampleMessagingScenarioFactory>());
             Assert.That(factory.Factories, Has.Exactly(1).InstanceOf<AnotherMessagingScenarioFactory>());
+            Assert.That(factory.Factories, Has.Exactly(1).InstanceOf<PermissiveMessagingScenarioFactory>());
 
             var exampleFactory = factory.Factories.OfType<ExampleMessagingScenarioFactory>().Single();
             var anotherFactory = factory.Factories.OfType<AnotherMessagingScenarioFactory>().Single();

--- a/Rock.Messaging.IntegrationTests/MQ/AnotherMessagingScenarioFactory.cs
+++ b/Rock.Messaging.IntegrationTests/MQ/AnotherMessagingScenarioFactory.cs
@@ -28,7 +28,7 @@ namespace Rock.Messaging
 
         public IReceiver CreateQueueConsumer(string name)
         {
-            throw new NotImplementedException();
+            return new TestReceiver(name, GetType());
         }
 
         public ISender CreateTopicPublisher(string name)
@@ -43,7 +43,7 @@ namespace Rock.Messaging
 
         public bool HasScenario(string name)
         {
-            throw new NotImplementedException();
+            return name == "foo" || name == "bar";
         }
 
         void IDisposable.Dispose()

--- a/Rock.Messaging.IntegrationTests/MQ/ExampleMessagingScenarioFactory.cs
+++ b/Rock.Messaging.IntegrationTests/MQ/ExampleMessagingScenarioFactory.cs
@@ -28,7 +28,7 @@ namespace Rock.Messaging
 
         public IReceiver CreateQueueConsumer(string name)
         {
-            throw new NotImplementedException();
+            return new TestReceiver(name, GetType());
         }
 
         public ISender CreateTopicPublisher(string name)
@@ -43,7 +43,7 @@ namespace Rock.Messaging
 
         public bool HasScenario(string name)
         {
-            throw new NotImplementedException();
+            return name == "foo";
         }
 
         void IDisposable.Dispose()

--- a/Rock.Messaging.IntegrationTests/MQ/OneMoreMessagingScenarioFactory.cs
+++ b/Rock.Messaging.IntegrationTests/MQ/OneMoreMessagingScenarioFactory.cs
@@ -1,0 +1,37 @@
+﻿using System;
+
+namespace Rock.Messaging
+{
+    public class PermissiveMessagingScenarioFactory : IMessagingScenarioFactory
+    {
+        public IReceiver CreateQueueConsumer(string name)
+        {
+            return new TestReceiver(name, GetType());
+        }
+
+        public ISender CreateQueueProducer(string name)
+        {
+            throw new NotImplementedException();
+        }
+
+        public ISender CreateTopicPublisher(string name)
+        {
+            throw new NotImplementedException();
+        }
+
+        public IReceiver CreateTopicSubscriber(string name)
+        {
+            throw new NotImplementedException();
+        }
+
+        public void Dispose()
+        {
+            throw new NotImplementedException();
+        }
+
+        public bool HasScenario(string name)
+        {
+            return name != "qux";
+        }
+    }
+}

--- a/Rock.Messaging.IntegrationTests/MQ/TestReceiver.cs
+++ b/Rock.Messaging.IntegrationTests/MQ/TestReceiver.cs
@@ -1,0 +1,26 @@
+﻿using System;
+
+namespace Rock.Messaging
+{
+    public class TestReceiver : IReceiver
+    {
+        public TestReceiver(string name, Type factoryType)
+        {
+            Name = name;
+            FactoryType = factoryType;
+        }
+
+        public string Name { get; }
+        public Type FactoryType { get; }
+
+        public event EventHandler<MessageReceivedEventArgs> MessageReceived;
+
+        public void Dispose()
+        {
+        }
+
+        public void Start(string selector)
+        {
+        }
+    }
+}

--- a/Rock.Messaging.IntegrationTests/Rock.Messaging.IntegrationTests.csproj
+++ b/Rock.Messaging.IntegrationTests/Rock.Messaging.IntegrationTests.csproj
@@ -46,9 +46,12 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="CompositeMessagingScenarioTests.cs" />
     <Compile Include="ConfigTests.cs" />
     <Compile Include="MQ\AnotherMessagingScenarioFactory.cs" />
+    <Compile Include="MQ\OneMoreMessagingScenarioFactory.cs" />
     <Compile Include="MQ\ExampleMessagingScenarioFactory.cs" />
+    <Compile Include="MQ\TestReceiver.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>

--- a/Rock.Messaging/MQ/CompositeMessagingScenarioFactory.cs
+++ b/Rock.Messaging/MQ/CompositeMessagingScenarioFactory.cs
@@ -53,7 +53,7 @@ namespace Rock.Messaging
 
         bool IMessagingScenarioFactory.HasScenario(string name)
         {
-            return Factories.Count(f => f.HasScenario(name)) == 1;
+            return Factories.Any(f => f.HasScenario(name));
         }
 
         /// <summary>
@@ -71,11 +71,11 @@ namespace Rock.Messaging
         {
             try
             {
-                return Factories.Single(f => f.HasScenario(name));
+                return Factories.First(f => f.HasScenario(name));
             }
             catch (Exception ex)
             {
-                throw new InvalidOperationException("Unable to locate a single configuration: " + name, ex);
+                throw new InvalidOperationException($"Unable to locate a messaging scenario with the name '{name}'.", ex);
             }
         }
     }


### PR DESCRIPTION
Prefer "first one wins" over of "there can be only one". By using LINQ's `.Single`, it ensures that "catch-all" type messaging scenario factories cannot co-exist with regular factories.