### PR TITLE
Increase RockLib.Messaging.Kafka version to rc10

### DIFF
--- a/RockLib.Messaging.Kafka/RockLib.Messaging.Kafka.csproj
+++ b/RockLib.Messaging.Kafka/RockLib.Messaging.Kafka.csproj
@@ -6,7 +6,7 @@
 
   <PropertyGroup>
     <PackageId>RockLib.Messaging.Kafka</PackageId>
-    <PackageVersion>1.0.0-rc9</PackageVersion>
+    <PackageVersion>1.0.0-rc10</PackageVersion>
     <Authors>RockLib</Authors>
     <Description>Implementation of RockLib.Messaging API that sends and receives messages using Kafka.</Description>
     <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>


### PR DESCRIPTION
## Description

Just need to increase the package version to 1.0.0-rc10 to release #118.

## Type of change:  Non-functional change

Bump the version that will allow us to package and release RockLib.Messaging.Kafka. #118 created a new constructor that supports specifying the schema id and producer config.